### PR TITLE
Publish `tmc-auth` SDK to public and private repositories for distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,16 @@ jobs:
           command: ../sonar.sh
 
   #publish artifact to OSS repo
-#  publish-public:
-#    executor: java-image
-#    steps:
-#      - checkout
-#
-#      - restore_cache:
-#          keys:
-#            - v3-publish-dependencies-{{ checksum "pom.xml" }}
-#      - run: mvn versions:set -DnewVersion=${CIRCLE_TAG}
-#      - run: mvn deploy -Prun-revapi
+  publish-public:
+    executor: java-image
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v3-publish-dependencies-{{ checksum "pom.xml" }}
+      - run: mvn versions:set -DnewVersion=${CIRCLE_TAG}
+      - run: mvn deploy -Prun-revapi,public
   publish-private:
     executor: private-java-image
     steps:
@@ -158,7 +158,7 @@ jobs:
           keys:
             - v3-publish-dependencies-{{ checksum "pom.xml" }}
       - run: mvn versions:set -DnewVersion=${CIRCLE_TAG}
-      - run: mvn deploy -Prun-revapi
+      - run: mvn deploy -Prun-revapi,private
 
 workflows:
   version: 2.1
@@ -183,6 +183,12 @@ workflows:
   release:
     jobs:
       #Run Publish on GitHub release
+      - publish-public:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
       - publish-private:
           filters:
             tags:

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2019-12-19 18:52
+Date Generated: 2019-12-19 21:24
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.9.9 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.9.9 - https://github.com/FasterXML/jackson-core)

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.autonomic.tmc</groupId>
     <artifactId>tmc-oss-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.2-alpha</version>
   </parent>
 
   <name>TMC Auth SDK</name>
@@ -164,48 +164,6 @@
       <properties>
         <tmc.integration.tests>true</tmc.integration.tests>
       </properties>
-    </profile>
-    <profile>
-      <id>run-revapi</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.revapi</groupId>
-            <artifactId>revapi-maven-plugin</artifactId>
-            <version>0.11.1</version>
-            <configuration>
-              <failSeverity>breaking</failSeverity>
-              <analysisConfiguration>
-                <revapi.semver.ignore>
-                  <enabled>true</enabled>
-                  <versionIncreaseAllows>
-                    <major>breaking</major>
-                    <minor>nonBreaking</minor>
-                    <patch>none</patch>
-                  </versionIncreaseAllows>
-                  <passThroughDifferences>
-                    <item>java.class.nonPublicPartOfAPI</item>
-                  </passThroughDifferences>
-                </revapi.semver.ignore>
-              </analysisConfiguration>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.revapi</groupId>
-                <artifactId>revapi-java</artifactId>
-                <version>0.19.1</version>
-              </dependency>
-            </dependencies>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
# Description

| **Story ID** | **Story Name** |
| ------------ | -------------- |
| #170381107 |  Figure out a way to deploy `tmc-oss-root-pom` and `tmc-auth` to our Bintray private repo |

***
## Summary of Changes: 
To enable publishing to the Private repository, distribution management was included in the tmc-oss-parent pom.xml which can be inherited. Distribution is encapsulated as a profile and invoked during deploy in CI/CD.

This pull request is considered a _Work In Progress_ unless all of the following boxes are checked.
Items not required for this release have been removed from this list by using a ~~strikethrough~~.

- [x] A secret scan was run:
    - [x] on every commit
    - [x] on every push
- [x] Existing tests of the following types were run
    - [x] unit tests
    - [x] integration tests
- [x] Application was run to ensure it is still working as expected
- [x] Examples given to customers still work as expected
- [x] Code quality gates have been meet:
    - [x] Code Coverage
    - [x] Sonar Quality Gate     

***
## PR Reviewer's Checklist
Be sure to give yourself enough time to review the PR.  We are looking for good approvals, not rubber stamped approvals.
- [ ] Pull down the branch
- [ ] Review the code
- [ ] Build the code
- [ ] Run tests, application and/or examples locally
- [ ] Review code's coverage
- [ ] Review code's Sonar quality gate


***
## Reviewers for this PR: 
- [ ] @autonomic-tmc/sdk-team
- [ ] @autonomic-tmc/fe-pr-reviewers