### PR TITLE
Revert lombok version to 1.18.0

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2020-02-11 15:56
+Date Generated: 2020-02-14 18:00
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)
@@ -63,7 +63,7 @@ Date Generated: 2020-02-11 15:56
  (Eclipse Public License 2.0) JUnit Platform Engine API (org.junit.platform:junit-platform-engine:1.6.0 - https://junit.org/junit5/)
  (Apache License, Version 2.0) org.opentest4j:opentest4j (org.opentest4j:opentest4j:1.2.0 - https://github.com/ota4j-team/opentest4j)
  (BSD 3-Clause) asm (org.ow2.asm:asm:7.0 - http://asm.ow2.org/)
- (MIT-License) Project Lombok (org.projectlombok:lombok:1.18.10 - https://projectlombok.org)
+ (MIT-License) Project Lombok (org.projectlombok:lombok:1.18.0 - https://projectlombok.org)
  (MIT-License) SLF4J API Module (org.slf4j:slf4j-api:1.7.12 - http://www.slf4j.org)
  (Apache License, Version 2.0) org.xmlunit:xmlunit-core (org.xmlunit:xmlunit-core:2.6.2 - https://www.xmlunit.org/)
  (BSD 3-Clause) org.xmlunit:xmlunit-legacy (org.xmlunit:xmlunit-legacy:2.6.2 - https://www.xmlunit.org/)

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.10</version>
+      <version>1.18.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
# Description

| **Story ID** | **Story Name** |
| ------------ | -------------- |
| 170773309 |  Update tmc-auth to get a new token 10 seconds before the actual token expiration time|

***
## Summary of Changes: 
RevApi plugin is blocking release because we updated version of lombok dependency from 1.18.0 to 1.18.10. We do not have any specific reason to update to 1.18.10 so we are changing it back to 1.18.0.

***
## Review readiness
This pull request is considered a _Work In Progress_ unless all of the following boxes are checked.
Items not required for this PR should be removed from the below list.

- [x] A secret scan was run:
    - [ ] on every commit
    - [ ] on every push
- [x] Existing tests of the following types were run:
    - [ ] unit tests
    - [ ] integration tests
- [x] Application was run to ensure it is still working as expected
- [x] Examples given to customers still work as expected
- [x] Code quality gates have been meet:
    - [ ] Code Coverage
    - [ ] Sonar Quality Gate     
- [x] Ensured no breaking changes to the public interface
- [ ] One of the following has been done:
    - [ ] Documentation was updated
    - [ ] A story was created to update the documentation

***
## PR Reviewer's Checklist
Be sure to give yourself enough time to review the PR.  We are looking for good approvals, not rubber stamped approvals.
- [x] Pull down the branch
- [x] Review the code
- [x] Build the code
- [x] Run tests, application and/or examples locally
- [ ] Review code's coverage
- [ ] Review code's Sonar quality gate


***
## Reviewers for this PR: 
- [ ] @autonomic-tmc/sdk-team
- [ ] @autonomic-tmc/fe-pr-reviewers
