### PR TITLE
fix: remove bt creds from examples

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2020-02-21 17:58
+Date Generated: 2020-02-25 19:36
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)
@@ -25,7 +25,7 @@ Date Generated: 2020-02-21 17:58
  (Apache License, Version 2.0) Guava: Google Core Libraries for Java (com.google.guava:guava:20.0 - https://github.com/google/guava/guava)
  (Apache License, Version 2.0) project ':json-path' (com.jayway.jsonpath:json-path:2.4.0 - https://github.com/jayway/JsonPath)
  (Apache License, Version 2.0) Nimbus LangTag (com.nimbusds:lang-tag:1.4.4 - https://bitbucket.org/connect2id/nimbus-language-tags)
- (Apache License, Version 2.0) Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt:8.6 - https://bitbucket.org/connect2id/nimbus-jose-jwt)
+ (Apache License, Version 2.0) Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt:8.8 - https://bitbucket.org/connect2id/nimbus-jose-jwt)
  (Apache License, Version 2.0) OAuth 2.0 SDK with OpenID Connect extensions (com.nimbusds:oauth2-oidc-sdk:6.23 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions)
  (CDDL 1.1) JavaMail API (com.sun.mail:javax.mail:1.6.1 - http://javaee.github.io/javamail/javax.mail)
  (Apache License, Version 2.0) Apache Commons Codec (commons-codec:commons-codec:1.10 - http://commons.apache.org/proper/commons-codec/)

--- a/examples/gradle-example/build.gradle
+++ b/examples/gradle-example/build.gradle
@@ -14,10 +14,6 @@ plugins {
 repositories {
     maven {
         url "https://autonomic.bintray.com/au-tmc-oss"
-        credentials {
-            username System.getenv('BT_PUBLIC_USERNAME')
-            password System.getenv('BT_PUBLIC_API_TOKEN')
-        }
     }
     maven {
         url "https://repo.maven.apache.org/maven2"

--- a/examples/maven-example/settings.xml
+++ b/examples/maven-example/settings.xml
@@ -3,8 +3,6 @@
   xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
   <servers>
     <server>
-      <username>${env.BT_PUBLIC_USERNAME}</username>
-      <password>${env.BT_PUBLIC_API_TOKEN}</password>
       <id>tmc</id>
     </server>
   </servers>


### PR DESCRIPTION
# Description

| **Story ID** | **Story Name** |
| ------------ | -------------- |
| #171411251 |  Run through the `tmc-auth` repo and make sure examples and everything work. |

***
## Summary of Changes: 
- Ran both sets of examples and verified that they worked without the variables
- Removed the wrappers as we should no longer need these
  - mvnw and etc.
  - gradlew and etc.

***
## Review readiness
This pull request is considered a _Work In Progress_ unless all of the following boxes are checked.
Items not required for this PR should be removed from the below list.

- [x] A secret scan was run:
    - [x] on every commit
    - [x] on every push
- [x] Existing tests of the following types were run:
    - [x] unit tests
    - [x] integration tests
- [x] Application was run to ensure it is still working as expected
- [x] Examples given to customers still work as expected

***
## PR Reviewer's Checklist
Be sure to give yourself enough time to review the PR.  We are looking for good approvals, not rubber stamped approvals.
- [x] Pull down the branch
- [x] Review the code
- [x] Build the code
- [x] Run tests, application and/or examples locally
- [x] Review code's coverage
- [ ] Review code's Sonar quality gate


***
## Reviewers for this PR: 
- [ ] @autonomic-tmc/sdk-team
- [ ] @autonomic-tmc/fe-pr-reviewers