### PR TITLE
chore(docs): make docs a little more intuitive based on a user discovery session 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Authenticating with TMC
+# Authenticating with the TMC
 
 ## Let's get authenticated with an example application
 
-We have built a runnable example application that demonstrates how to include the `tmc-auth` SDK and connect to TMC services in a secure manner. You can use this example application to login and retrieve an access token.
+We have built a runnable example application that demonstrates how to authenticate on the TMC using the `tmc-auth` SDK. This example application will login and retrieve an access token which is used when accessing TMC services.
 
 - [Getting authenticated using the Maven Example](./examples/maven-example)
 - [Getting authenticated using the Gradle Example](./examples/gradle-example)
@@ -15,10 +15,10 @@ With this library, you don't need to worry about expiring tokens. The token you 
 
 ## Adding tmc-auth as a dependency
 
+See our [examples](examples) for more information on including this library in your Maven or Gradle project. It is distributed as a JAR file for easy consumption.
+
 - [Maven - pom.xml](./examples/maven-example/pom.xml)
 - [Gradle - build.gradle](./examples/gradle-example/build.gradle)
-
-See our [examples](examples) for more information on including this library in your Maven or Gradle project.
 
 ## Usage
 
@@ -42,7 +42,7 @@ See our [examples](examples) for more information on including this library in y
 
 ## Troubleshooting
 
-The `ClientCredentialsTokenSupplier.get()` primarily throws two exceptions:
+The [ClientCredentialsTokenSupplier.get()](src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java) primarily throws two exceptions:
 
 [AuthenticationCommunicationException](src/main/java/com/autonomic/tmc/auth/AuthenticationCommunicationException.java) - A temporary communication problem, and retrying at a later point will likely succeed.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ See our [examples](examples) for more information on including this library in a
 - [Maven Setup](./examples/maven-example)
 - [Gradle Setup](./examples/gradle-example)
 
-## Example Usage
+## Usage
+
 ```java
     TokenSupplier supplier = ClientCredentialsTokenSupplier.builder()
         .clientId("<your-client-id>")
@@ -41,6 +42,7 @@ The `ClientCredentialsTokenSupplier.get()` primarily throws two exceptions:
 [AuthenticationFailedException](src/main/java/com/autonomic/tmc/auth/AuthenticationFailedException.java) Your credentials are incorrect and should be corrected before calling again.
 
 ## Building
+
 ```shell
 ./mvnw clean install
 ```
@@ -67,6 +69,7 @@ For example:
 ```
 
 ## 3rd Party Components
+
 This project has binary dependencies on other open source projects.  These components are listed in the [THIRD-PARTY.txt](THIRD-PARTY.txt) file.
 
 ## Tools we use

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ With this library, you don't need to worry about expiring tokens. The token you 
 In order to use this dependency in your application, you will need to include the Autonomic's distribution repository as part of your build configuration.
 See our [examples](examples) for more information on including this library in a Maven or Gradle project.
 
-- [Maven Setup](./examples/maven-example/README.md#maven-setup)
-- [Gradle Setup](./examples/gradle-example/README.md#gradle-setup)
+- [Maven Setup](./examples/maven-example)
+- [Gradle Setup](./examples/gradle-example)
 
 ## Example Usage
 ```java

--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
-# Autonomic Authentication Module
+# Authenticating with TMC
 
-## Overview
+## Let's get authenticated with an example application
 
-Using the tmc-auth module with credentials provided by Autonomic, you can obtain a time-limited access token to be used with other services available on the platform.
+We have built a runnable example application that demonstrates how to include the `tmc-auth` SDK and connect to TMC services in a secure manner. You can use this example application to login and retrieve an access token.
+
+- [Getting authenticated using the Maven Example](./examples/maven-example)
+- [Getting authenticated using the Gradle Example](./examples/gradle-example)
+
+## tmc-auth SDK
+
+Using the tmc-auth SDK with credentials provided by Autonomic, you can obtain a time-limited access token to be used with other services available on the platform.
+
 With this library, you don't need to worry about expiring tokens. The token you `get()` is always valid.  If a token expires, this library will automatically get a new one.
 
 ## Adding tmc-auth as a dependency
 
-In order to use this dependency in your application, you will need to include the Autonomic's distribution repository as part of your build configuration.
-See our [examples](examples) for more information on including this library in a Maven or Gradle project.
+- [Maven - pom.xml](./examples/maven-example/pom.xml)
+- [Gradle - build.gradle](./examples/gradle-example/build.gradle)
 
-- [Maven Setup](./examples/maven-example)
-- [Gradle Setup](./examples/gradle-example)
+See our [examples](examples) for more information on including this library in your Maven or Gradle project.
 
 ## Usage
 

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2020-02-25 19:36
+Date Generated: 2020-02-28 16:40
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)

--- a/examples/gradle-example/README.md
+++ b/examples/gradle-example/README.md
@@ -1,5 +1,20 @@
 # TMC Auth Example Using Gradle
 
+## Overview
+
+This example shows you how to:
+
+ 1. Get a REST Authentication token for Production
+ 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
+ 3. Create an authenticated gRPC channel that can be used when creating a client stub
+
+### Prerequisites
+
+In order to begin integrating with the TMC, we require the following:
+
+- At least Java 8 installed
+- Access to the TMC Platform (Your Client Id and Client Secret that have been provided to you)
+
 ## Step 1: Configure the example application
 
 The following properties should be added to your environment or this example's [application.yml](src/main/resources/application.yml) file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
@@ -17,48 +32,18 @@ From the project directory, run the following:
 
 *Windows:* `gradlew clean build run` or `run.bat`
 
-## Overview
+## More information on the Example Application
 
-This example shows you how to:
-
- 1. Get a REST Authentication token for Production
- 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
- 3. Create an authenticated gRPC channel that can be used when creating a client stub
-
-### Prerequisites
-
-In order to begin integrating with the TMC, we require the following:
-
-- At least Java 8 installed
-- Access to the TMC Platform (Your Client Id and Client Secret that have been provided to you)
+### How the Example Authenticates
+See [GradleAuthExample.java](src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java) class for an example of using the `tmc-auth` SDK to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
 
 ### Gradle Setup
 
-To access Autonomic's open source dependencies, you can add a maven url to the repositories section of your [build.gradle](build.gradle) file, for example:
+To access Autonomic's open source dependencies, you can add a maven url to the repositories section of your `build.gradle` file.  See the [build.gradle](build.gradle) file for an example.
 
-```groovy
-repositories {
-    // other repositories here...
-    maven {
-        url "https://autonomic.bintray.com/au-tmc-oss"
-    }
-}
-```
+### Including the tmc-auth Gradle Dependency
 
-## Including the tmc-auth Gradle Dependency
-
-Add the `tmc-auth` client library to the `dependencies` section of your [build.gradle](build.gradle). **Note:** Verify the version you wish to include. This dependency is already included in this example application, for example:
-
-```groovy
-dependencies {
-    implementation("com.autonomic.tmc:tmc-auth:2.0.3-alpha")
-    ...
-}
-```
-
-## Example Application
-
-Familiarize yourself with the [GradleAuthExample.java](src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java) class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
+Add the `tmc-auth` client library to the `dependencies` section of your `build.gradle`. See the [build.gradle](build.gradle) file for an example.
 
 ### Optional: Configuration for Another Environment
 
@@ -76,7 +61,7 @@ Property|Description|Required/Optional|Default Value|
 |------|------|-----------------------|------|
 |tmc.some-service.serviceUrl|The url of the service you wish to connect to securely.|Optional| Dependent on service. |
 
-## Compiling the Code
+### Compiling the Code
 
 A Gradle wrapper is included in this project for you. By using the Gradle wrapper, you will be able to build the project without having to install Gradle locally.
 

--- a/examples/gradle-example/README.md
+++ b/examples/gradle-example/README.md
@@ -1,18 +1,35 @@
 # TMC Auth Example Using Gradle
 
-This example shows you how to:
- 1. Get a REST Authentication token for Production 
- 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to 
- 3. Create an authenticated gRPC channel that can be used when creating a client stub 
+## Step 1: Configure the example application
 
-## Steps to get started
+The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
+
+|Property|Environment Variable|Description|Required/Optional|
+|------|------|------|-----------------------|
+|tmc.auth.clientId|TMC_CLIENT_ID|This is your TMC Client identifier.|Required|
+|tmc.auth.clientSecret|TMC_CLIENT_SECRET|This is your TMC Client secret.|Required|
+
+## Step 2: Run the example application
+
+From the project directory, run the following:
+
+*Linux/Mac:* `./gradlew clean build run` or `./run.sh`
+
+*Windows:* `gradlew clean build run` or `run.bat`
+
+## Overview
+
+This example shows you how to:
+
+ 1. Get a REST Authentication token for Production
+ 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
+ 3. Create an authenticated gRPC channel that can be used when creating a client stub
 
 ### Prerequisites
 
 In order to begin integrating with the TMC, we require the following:
 
 - At least Java 8 installed
-- Access to Autonomic's Bintray instance
 - Access to the TMC Platform (Your Client Id and Client Secret that have been provided to you)
 
 ### Gradle Setup
@@ -46,15 +63,6 @@ dependencies {
 
 Familiarize yourself with the `GradleAuthExample.java` class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
 
-## Configuration
-
-The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
-
-|Property|Environment Variable|Description|Required/Optional|
-|------|------|------|-----------------------|
-|tmc.auth.clientId|TMC_CLIENT_ID|This is your TMC Client identifier.|Required|
-|tmc.auth.clientSecret|TMC_CLIENT_SECRET|This is your TMC Client secret.|Required|
-
 ### Optional: Configuration for Another Environment
 
 By default, this example assumes you want to connect to Autonomic's production environment.  However, Autonomic may have provided you access to another environment for testing and validation. To test tmc-auth in another environment, you should set the following value:
@@ -78,20 +86,6 @@ A Gradle wrapper is included in this project for you. By using the Gradle wrappe
 Linux/Mac: `./gradlew clean build`
 
 Windows: `gradlew clean build`
-
-## Running the Application
-
-Use the command below:
-
-*Linux/Mac:*
-```bash
-./gradlew clean build run
-```
-
-*Windows:*
-```cmd
-gradlew clean build run
-```
 
 ## Helpful Information
 

--- a/examples/gradle-example/README.md
+++ b/examples/gradle-example/README.md
@@ -2,7 +2,7 @@
 
 ## Step 1: Configure the example application
 
-The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
+The following properties should be added to your environment or this example's [application.yml](src/main/resources/application.yml) file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
 
 |Property|Environment Variable|Description|Required/Optional|
 |------|------|------|-----------------------|
@@ -34,7 +34,7 @@ In order to begin integrating with the TMC, we require the following:
 
 ### Gradle Setup
 
-To access Autonomic's open source dependencies, you can add a maven url to the repositories section of your `build.gradle` file, for example:
+To access Autonomic's open source dependencies, you can add a maven url to the repositories section of your [build.gradle](build.gradle) file, for example:
 
 ```groovy
 repositories {
@@ -47,21 +47,18 @@ repositories {
 
 ## Including the tmc-auth Gradle Dependency
 
-Add the `tmc-auth` client library to the `dependencies` section of your build.gradle. **Note:** Verify the version you wish to include. This dependency is already included in this example application.
+Add the `tmc-auth` client library to the `dependencies` section of your [build.gradle](build.gradle). **Note:** Verify the version you wish to include. This dependency is already included in this example application, for example:
 
 ```groovy
 dependencies {
-    implementation("com.autonomic.tmc:tmc-auth:${TMC_AUTH_VERSION}")
-    implementation("io.grpc:grpc-stub:1.25.0")
-    implementation("io.grpc:grpc-netty:1.25.0")
-    implementation("io.netty:netty-tcnative-boringssl-static:2.0.28.Final")
-    implementation("org.springframework.boot:spring-boot-starter:2.2.1.RELEASE")
+    implementation("com.autonomic.tmc:tmc-auth:2.0.3-alpha")
+    ...
 }
 ```
 
 ## Example Application
 
-Familiarize yourself with the `GradleAuthExample.java` class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
+Familiarize yourself with the [GradleAuthExample.java](src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java) class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
 
 ### Optional: Configuration for Another Environment
 

--- a/examples/gradle-example/build.gradle
+++ b/examples/gradle-example/build.gradle
@@ -15,9 +15,6 @@ repositories {
     maven {
         url "https://autonomic.bintray.com/au-tmc-oss"
     }
-    maven {
-        url "https://repo.maven.apache.org/maven2"
-    }
 }
 
 dependencies {

--- a/examples/gradle-example/build.gradle
+++ b/examples/gradle-example/build.gradle
@@ -12,6 +12,8 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
+    jcenter()
     maven {
         url "https://autonomic.bintray.com/au-tmc-oss"
     }

--- a/examples/maven-example/README.md
+++ b/examples/maven-example/README.md
@@ -1,5 +1,20 @@
 # TMC Auth Example Using Maven
 
+## Overview
+
+This example shows you how to:
+
+ 1. Get a REST Authentication token for Production
+ 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
+ 3. Create an authenticated gRPC channel that can be used when creating a client stub
+
+### Prerequisites
+
+In order to begin integrating with the TMC, we require the following:
+
+- At least Java 8 installed
+- Access to the TMC Platform (Your Client Id and Client Secret that have been provided to you)
+
 ## Step 1: Configure the example application
 
 The following properties should be added to your environment or this example's [application.yml](src/main/resources/application.yml) file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
@@ -17,71 +32,20 @@ From the project directory, run the following:
 
 *Windows*: `mvnw -s .\settings.xml spring-boot:run` or `run.bat`
 
-## Overview
+## More information on the Example Application
 
-This example shows you how to:
-
- 1. Get a REST Authentication token for Production
- 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
- 3. Create an authenticated gRPC channel that can be used when creating a client stub
-
-### Prerequisites
-
-In order to begin integrating with the TMC, we require the following:
-
-- At least Java 8 installed
-- Access to the TMC Platform (Your Client Id and Client Secret that have been provided to you)
+### How the Example Authenticates
+See [MavenAuthExample.java](src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java) class for an example of using the `tmc-auth` SDK to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
 
 ### Maven Setup
 
-To access Autonomic's open source dependencies, you can add a Maven url to the repositories section of your [settings.xml](settings.xml) file, for example:
-
-```xml
-<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0'
-  xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'
-  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-  <profiles>
-    <profile>
-      <repositories>
-        <repository>
-          <id>tmc</id>
-          <name>bintray</name>
-          <url>https://autonomic.bintray.com/au-tmc-oss</url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>tmc</id>
-          <name>bintray-plugins</name>
-          <url>https://autonomic.bintray.com/au-tmc-oss</url>
-        </pluginRepository>
-      </pluginRepositories>
-      <id>tmc</id>
-    </profile>
-  </profiles>
-  <activeProfiles>
-    <activeProfile>tmc</activeProfile>
-  </activeProfiles>
-</settings>
-```
+To access Autonomic's open source dependencies, you can add a Maven url to the repositories section of your `settings.xml` file. See the [settings.xml](settings.xml) file for an example.
 
 To use this settings file, it needs to either be placed in your `~/.m2` directory on Mac or `%userprofile%\.m2` on Windows. The settings file can also be invoked directly with the `-s` command line option (eg, `./mvnw -s these-settings.xml clean verify`).
 
-## Including the tmc-auth Maven Dependency
+### Including the tmc-auth Maven Dependency
 
-Add the `tmc-auth` client library to the `<dependencies>` section of your pom.xml. **Note:** Verify the version you wish to include. This dependency is already included in this example application.
-
-```maven
-<dependency>
-  <groupId>com.autonomic.tmc</groupId>
-  <artifactId>tmc-auth</artifactId>
-  <version>2.0.3-alpha</version>
-</dependency>
-```
-
-## Example Application
-
-Familiarize yourself with the [MavenAuthExample.java](src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java) class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
+Add the `tmc-auth` client library to the `<dependencies>` section of your pom.xml. See the [pom.xml](pom.xml) file for an example.
 
 ### Optional: Configuration for Another Environment
 
@@ -99,7 +63,7 @@ Property|Description|Required/Optional|Default Value|
 |------|------|-----------------------|------|
 |tmc.some-service.serviceUrl|The url of the service you wish to connect to securely.|Optional| Dependent on service.
 
-## Compiling the Code
+### Compiling the Code
 
 A Maven wrapper is included in this project and references a project specific settings.xml. See [Maven Setup](#maven-setup) for an example of the `settings.xml` file.
 

--- a/examples/maven-example/README.md
+++ b/examples/maven-example/README.md
@@ -75,7 +75,7 @@ Add the `tmc-auth` client library to the `<dependencies>` section of your pom.xm
 <dependency>
   <groupId>com.autonomic.tmc</groupId>
   <artifactId>tmc-auth</artifactId>
-  <version>${TMC_AUTH_VERSION}</version>
+  <version>2.0.3-alpha</version>
 </dependency>
 ```
 

--- a/examples/maven-example/README.md
+++ b/examples/maven-example/README.md
@@ -2,7 +2,7 @@
 
 ## Step 1: Configure the example application
 
-The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
+The following properties should be added to your environment or this example's [application.yml](src/main/resources/application.yml) file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
 
 |Property|Environment Variable|Description|Required/Optional|
 |------|------|------|-----------------------|
@@ -34,7 +34,7 @@ In order to begin integrating with the TMC, we require the following:
 
 ### Maven Setup
 
-To access Autonomic's open source dependencies, you can add a Maven url to the repositories section of your `settings.xml` file, for example:
+To access Autonomic's open source dependencies, you can add a Maven url to the repositories section of your [settings.xml](settings.xml) file, for example:
 
 ```xml
 <settings xmlns='http://maven.apache.org/SETTINGS/1.0.0'
@@ -81,7 +81,7 @@ Add the `tmc-auth` client library to the `<dependencies>` section of your pom.xm
 
 ## Example Application
 
-Familiarize yourself with the `MavenAuthExample.java` class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
+Familiarize yourself with the [MavenAuthExample.java](src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java) class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
 
 ### Optional: Configuration for Another Environment
 
@@ -97,7 +97,7 @@ This example exposes the `tmc.some-service.serviceUrl` property for testing and 
 
 Property|Description|Required/Optional|Default Value|
 |------|------|-----------------------|------|
-|tmc.some-service.serviceUrl|The url of the service you wish to connect to securely.|Optional| Dependent on service. 
+|tmc.some-service.serviceUrl|The url of the service you wish to connect to securely.|Optional| Dependent on service.
 
 ## Compiling the Code
 

--- a/examples/maven-example/README.md
+++ b/examples/maven-example/README.md
@@ -1,9 +1,10 @@
 # TMC Auth Example Using Maven
 
 This example shows you how to:
- 1. Get a REST Authentication token for Production 
- 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to 
- 3. Create an authenticated gRPC channel that can be used when creating a client stub 
+
+ 1. Get a REST Authentication token for Production
+ 2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
+ 3. Create an authenticated gRPC channel that can be used when creating a client stub
 
 ## Steps to get started
 
@@ -65,15 +66,6 @@ Add the `tmc-auth` client library to the `<dependencies>` section of your pom.xm
 ## Example Application
 
 Familiarize yourself with the `MavenAuthExample.java` class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
-
-## Configuration
-
-The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
-
-|Property|Environment Variable|Description|Required/Optional|
-|------|------|------|-----------------------|
-|tmc.auth.clientId|TMC_CLIENT_ID|This is your TMC Client identifier.|Required|
-|tmc.auth.clientSecret|TMC_CLIENT_SECRET|This is your TMC Client secret.|Required|
 
 ## Configuration
 

--- a/examples/maven-example/README.md
+++ b/examples/maven-example/README.md
@@ -13,9 +13,9 @@ The following properties should be added to your environment or this example's `
 
 From the project directory, run the following:
 
-Linux/Mac: `./mvnw -s ./settings.xml spring-boot:run` or `./run.sh`
+*Linux/Mac*: `./mvnw -s ./settings.xml spring-boot:run` or `./run.sh`
 
-Windows: `mvnw -s .\settings.xml spring-boot:run` or `run.bat`
+*Windows*: `mvnw -s .\settings.xml spring-boot:run` or `run.bat`
 
 ## Overview
 
@@ -30,7 +30,6 @@ This example shows you how to:
 In order to begin integrating with the TMC, we require the following:
 
 - At least Java 8 installed
-- Access to Autonomic's Bintray instance
 - Access to the TMC Platform (Your Client Id and Client Secret that have been provided to you)
 
 ### Maven Setup

--- a/examples/maven-example/README.md
+++ b/examples/maven-example/README.md
@@ -1,12 +1,29 @@
 # TMC Auth Example Using Maven
 
+## Step 1: Configure the example application
+
+The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
+
+|Property|Environment Variable|Description|Required/Optional|
+|------|------|------|-----------------------|
+|tmc.auth.clientId|TMC_CLIENT_ID|This is your TMC Client identifier.|Required|
+|tmc.auth.clientSecret|TMC_CLIENT_SECRET|This is your TMC Client secret.|Required|
+
+## Step 2: Run the example application
+
+From the project directory, run the following:
+
+Linux/Mac: `./mvnw -s ./settings.xml spring-boot:run` or `./run.sh`
+
+Windows: `mvnw -s .\settings.xml spring-boot:run` or `run.bat`
+
+## Overview
+
 This example shows you how to:
 
  1. Get a REST Authentication token for Production
  2. Get a REST Authentication token when you want to tell the tokenSupplier what environment to connect to
  3. Create an authenticated gRPC channel that can be used when creating a client stub
-
-## Steps to get started
 
 ### Prerequisites
 
@@ -67,15 +84,6 @@ Add the `tmc-auth` client library to the `<dependencies>` section of your pom.xm
 
 Familiarize yourself with the `MavenAuthExample.java` class for an example of using the `tmc-auth` client library to retrieve an access token to the TMC. This class also provides an example of creating an authenticated gRPC channel.
 
-## Configuration
-
-The following properties should be added to your environment or this example's `application.yml` file. Notice that the `application.yml` file references two environment variables which you should set in your environment in order to help protect sensitive credentials.
-
-|Property|Environment Variable|Description|Required/Optional|
-|------|------|------|-----------------------|
-|tmc.auth.clientId|TMC_CLIENT_ID|This is your TMC Client identifier.|Required|
-|tmc.auth.clientSecret|TMC_CLIENT_SECRET|This is your TMC Client secret.|Required|
-
 ### Optional: Configuration for Another Environment
 
 By default, this example assumes you want to connect to Autonomic's production environment.  However, Autonomic may have provided you access to another environment for testing and validation. To test tmc-auth in another environment, you should set the following value:
@@ -101,14 +109,6 @@ By using the maven wrapper, you will be able to build the project without having
 Linux/Mac: `./mvnw -s ./settings.xml clean install`
 
 Windows: `mvnw -s .\settings.xml clean install`
-
-## Running the Application
-
-From the project directory, run the following:
-
-Linux/Mac: `./mvnw -s ./settings.xml spring-boot:run`
-
-Windows: `mvnw -s .\settings.xml spring-boot:run`
 
 ## Helpful Information
 


### PR DESCRIPTION
***
## Summary of Changes: 

- Make sure people know that the examples are runnable, and they are the best way to see how our authentication works for TMC services
- Maven Setup and Gradle Setup links should go to the examples directories, not directly to the README.md
- Rename "Example Usage" to just "Usage"
- Add common repos needed in the build. Remove the maven2 url.
- Make how to run the examples most important - 1. What you'll need. 2. RUN!
- Remove code snippets and link to the source code file directly.

***
## Review readiness
This pull request is considered a _Work In Progress_ unless all of the following boxes are checked.
Items not required for this PR should be removed from the below list.

- [x] Examples given to customers still work as expected
- [x] One of the following has been done:
    - [x] Documentation was updated

***
## PR Reviewer's Checklist
Be sure to give yourself enough time to review the PR.  We are looking for good approvals, not rubber stamped approvals.

- [x] Pull down the branch
- [x] Review the docs
- [x] Follow the instructions and make sure they make sense and work for the reader.

***
## Reviewers for this PR: 
- [x] @autonomic-tmc/sdk-team
- [ ] @autonomic-tmc/fe-pr-reviewers
