### PR TITLE
chore: Remove Bintray to Cloudsmith announcement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@ file or class name and description of purpose be included on the
 same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright 2016 - 2020 Autonomic, LLC
+Copyright 2016 - 2021 Autonomic, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,5 @@
 # Authenticating with the TMC
 
----
-|📣 ANNOUNCEMENT: Autonomic's artifacts have moved from Bintray to [Cloudsmith](https://cloudsmith.com/) 📣|
-|---|
-
-If you are using `tmc-auth 3.0.5-beta` or earlier, you will need to replace:
-  -  The Bintray URL `https://autonomic.bintray.com/au-tmc-oss`
- -  With a Cloudsmith URL `https://dl.cloudsmith.io/public/autonomic/au-tmc-oss/maven/`
-
-If you are using Maven, these URLs can be found in your `settings.xml`,  or `pom.xml`.
-
-If you are using Gradle, these URLs can be found in your `init.gradle`, `build.gradle`,  or `build.gradle.kts`.
-
----
-
 ## tmc-auth SDK
 
 Using the tmc-auth SDK with credentials provided by Autonomic, you can obtain a time-limited access token to be used with other services available on the platform.
@@ -33,6 +19,8 @@ See our [examples](examples) for more information on including this library in y
 
 - [Maven - pom.xml](./examples/maven-example/pom.xml)
 - [Gradle - build.gradle](./examples/gradle-example/build.gradle)
+
+> Are you using a different build tool other than Maven or Gradle? Or, are you interested in just browsing what is available in our repository? Or, do you just need to download `tmc-auth`'s required jar files directly? You can find everything you need in our [Cloudsmith](https://cloudsmith.io/~autonomic/repos/au-tmc-oss/groups/) repository.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See our [examples](examples) for more information on including this library in y
 - [Maven - pom.xml](./examples/maven-example/pom.xml)
 - [Gradle - build.gradle](./examples/gradle-example/build.gradle)
 
-> Are you using a different build tool other than Maven or Gradle? Or, are you interested in just browsing what is available in our repository? Or, do you just need to download `tmc-auth`'s required jar files directly? You can find everything you need in our [Cloudsmith](https://cloudsmith.io/~autonomic/repos/au-tmc-oss/groups/) repository.
+> Are you using a different build tool other than Maven or Gradle? Are you interested in just browsing what is available in our repository? Do you want to download the jar files required for `tmc-auth` directly? You can find everything you need in our [Cloudsmith](https://cloudsmith.io/~autonomic/repos/au-tmc-oss/groups/) repository.
 
 ## Usage
 


### PR DESCRIPTION
# Description

| **Story ID** | **Story Name** |
| ------------ | -------------- |
| #176666482 | Remove Cloudsmith announcement from tmc-auth README |

***
## Summary of Changes: 
* Removed the "Bintray to Cloudsmith announcement" section from the top of the README page
* Under "Adding tmc-auth as a dependency", added documentation about being able to pull binaries from Cloudsmith

***
## Review readiness
This pull request is considered a _Work In Progress_ unless all of the following boxes are checked.
Items not required for this PR should be removed from the below list.

- [x] A secret scan was run:
    - [x] on every commit
    - [x] on every push
- [x] Existing tests of the following types were run:
    - [x] unit tests
    - [x] integration tests

***
## PR Reviewer's Checklist
Be sure to give yourself enough time to review the PR.  We are looking for good approvals, not rubber stamped approvals.
- [ ] Pull down the branch
- [ ] Review the code
- [ ] Build the code

***
## Reviewers for this PR: 
- [ ] @autonomic-tmc/sdk-team
