### PR TITLE
An exception in the BaseSdkException should never cause a customer to lose the root cause

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2021-03-10 15:15
+Date Generated: 2021-03-10 16:30
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2021-03-10 16:48
+Date Generated: 2021-03-11 13:24
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2020-12-17 19:47
+Date Generated: 2021-03-09 13:48
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)
@@ -25,7 +25,7 @@ Date Generated: 2020-12-17 19:47
  (Apache License, Version 2.0) Guava: Google Core Libraries for Java (com.google.guava:guava:20.0 - https://github.com/google/guava/guava)
  (Apache License, Version 2.0) project ':json-path' (com.jayway.jsonpath:json-path:2.4.0 - https://github.com/jayway/JsonPath)
  (Apache License, Version 2.0) Nimbus LangTag (com.nimbusds:lang-tag:1.5 - https://bitbucket.org/connect2id/nimbus-language-tags)
- (Apache License, Version 2.0) Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt:9.2 - https://bitbucket.org/connect2id/nimbus-jose-jwt)
+ (Apache License, Version 2.0) Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt:9.7 - https://bitbucket.org/connect2id/nimbus-jose-jwt)
  (Apache License, Version 2.0) OAuth 2.0 SDK with OpenID Connect extensions (com.nimbusds:oauth2-oidc-sdk:6.23 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions)
  (CDDL 1.1) JavaMail API (com.sun.mail:javax.mail:1.6.1 - http://javaee.github.io/javamail/javax.mail)
  (Apache License, Version 2.0) Apache Commons Codec (commons-codec:commons-codec:1.10 - http://commons.apache.org/proper/commons-codec/)

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2021-03-09 13:48
+Date Generated: 2021-03-10 15:15
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -12,7 +12,7 @@ RESULTING FROM ANY USE OR DISTRIBUTION OF THIS LIST.
 
 In case of any license issues related to TMC Auth SDK, please contact support@autonomic.ai.
 
-Date Generated: 2021-03-10 16:30
+Date Generated: 2021-03-10 16:48
 
  (Apache License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.10.2 - http://github.com/FasterXML/jackson)
  (Apache License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.10.2 - https://github.com/FasterXML/jackson-core)

--- a/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
+++ b/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
@@ -56,7 +56,8 @@ public class GradleAuthExample implements CommandLineRunner {
             tokenSupplier = createTokenSupplier(clientId, clientSecret);
             printToken(tokenSupplier, "with default URL");
         } catch (BaseSdkException e) {
-            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+            LOGGER.log(Level.SEVERE,
+                "Example 1: REST Authentication token for Production failed: ", e);
         }
 
         //Example 2: REST Authentication token when you want to tell the tokenSupplier what
@@ -65,7 +66,8 @@ public class GradleAuthExample implements CommandLineRunner {
             tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
             printToken(tokenSupplier, "with provided URL");
         } catch (BaseSdkException e) {
-            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+            LOGGER.log(Level.SEVERE,
+                "Example 2: REST Authentication token for your environment failed: ", e);
         }
 
         //Example 3: An authenticated gRPC channel that can be used when creating a client stub
@@ -78,7 +80,8 @@ public class GradleAuthExample implements CommandLineRunner {
             String msg = format("Authenticated Channel: %s", authenticatedGRPCChannel);
             LOGGER.info(msg);
         } catch (BaseSdkException | MalformedURLException e) {
-            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+            LOGGER.log(Level.SEVERE,
+                "Example 3: A gRPC authenticated token failed: ", e);
         }
 
         // ExampleStub exampleStub = ExampleGrpc.newStub(authenticatedGRPCChannel);

--- a/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
+++ b/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
@@ -51,16 +51,24 @@ public class GradleAuthExample implements CommandLineRunner {
 
     private void run() {
         try {
-            TokenSupplier tokenSupplier;
+            TokenSupplier tokenSupplier = null;
 
             //#Example 1: REST Authentication token for Production
-            tokenSupplier = createTokenSupplier(clientId, clientSecret);
-            printToken(tokenSupplier, "with default URL");
+            try {
+                tokenSupplier = createTokenSupplier(clientId, clientSecret);
+                printToken(tokenSupplier, "with default URL");
+            } catch (RuntimeException e) {
+                e.printStackTrace();
+            }
 
             //Example 2: REST Authentication token when you want to tell the tokenSupplier what
             // environment to connect to
-            tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
-            printToken(tokenSupplier, "with provided URL");
+            try {
+                tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
+                printToken(tokenSupplier, "with provided URL");
+            } catch (RuntimeException e) {
+                e.printStackTrace();
+            }
 
             //Example 3: An authenticated gRPC channel that can be used when creating a client stub
             AuthenticatedChannelBuilder channelBuilder = new AuthenticatedChannelBuilder(

--- a/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
+++ b/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
@@ -23,10 +23,10 @@ public class GradleAuthExample implements CommandLineRunner {
     @VisibleForTesting
     static Logger LOGGER = Logger.getLogger("GradleAuthExample");
 
-    @Value("${tmc.auth.clientId}")
+    @Value("${tmc.auth.clientId: }")
     private String clientId;
 
-    @Value("${tmc.auth.clientSecret}")
+    @Value("${tmc.auth.clientSecret: }")
     private String clientSecret;
 
     @Value("${tmc.auth.tokenUrl:https://accounts.autonomic.ai/v1/auth/oidc/token}")

--- a/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
+++ b/examples/gradle-example/src/main/java/com/autonomic/tmc/example/auth/GradleAuthExample.java
@@ -4,8 +4,7 @@ import static java.lang.String.format;
 
 import com.autonomic.tmc.auth.ClientCredentialsTokenSupplier;
 import com.autonomic.tmc.auth.TokenSupplier;
-import com.autonomic.tmc.auth.exception.SdkClientException;
-import com.autonomic.tmc.auth.exception.SdkServiceException;
+import com.autonomic.tmc.auth.exception.BaseSdkException;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Channel;
 import java.net.MalformedURLException;
@@ -50,27 +49,27 @@ public class GradleAuthExample implements CommandLineRunner {
     }
 
     private void run() {
+        TokenSupplier tokenSupplier = null;
+
+        //#Example 1: REST Authentication token for Production
         try {
-            TokenSupplier tokenSupplier = null;
+            tokenSupplier = createTokenSupplier(clientId, clientSecret);
+            printToken(tokenSupplier, "with default URL");
+        } catch (BaseSdkException e) {
+            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+        }
 
-            //#Example 1: REST Authentication token for Production
-            try {
-                tokenSupplier = createTokenSupplier(clientId, clientSecret);
-                printToken(tokenSupplier, "with default URL");
-            } catch (RuntimeException e) {
-                e.printStackTrace();
-            }
+        //Example 2: REST Authentication token when you want to tell the tokenSupplier what
+        // environment to connect to
+        try {
+            tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
+            printToken(tokenSupplier, "with provided URL");
+        } catch (BaseSdkException e) {
+            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+        }
 
-            //Example 2: REST Authentication token when you want to tell the tokenSupplier what
-            // environment to connect to
-            try {
-                tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
-                printToken(tokenSupplier, "with provided URL");
-            } catch (RuntimeException e) {
-                e.printStackTrace();
-            }
-
-            //Example 3: An authenticated gRPC channel that can be used when creating a client stub
+        //Example 3: An authenticated gRPC channel that can be used when creating a client stub
+        try {
             AuthenticatedChannelBuilder channelBuilder = new AuthenticatedChannelBuilder(
                 tokenSupplier);
 
@@ -78,16 +77,15 @@ public class GradleAuthExample implements CommandLineRunner {
 
             String msg = format("Authenticated Channel: %s", authenticatedGRPCChannel);
             LOGGER.info(msg);
-
-            // ExampleStub exampleStub = ExampleGrpc.newStub(authenticatedGRPCChannel);
-            //
-            // Note: `newStub` could also be a blocking stub, and async call stub, and a future
-            // stub. Check with the Autonomic service to learn what is the best stub to use for the
-            // service.
-
-        } catch (SdkClientException | SdkServiceException | MalformedURLException e) {
+        } catch (BaseSdkException | MalformedURLException e) {
             LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
         }
+
+        // ExampleStub exampleStub = ExampleGrpc.newStub(authenticatedGRPCChannel);
+        //
+        // Note: `newStub` could also be a blocking stub, and async call stub, and a future
+        // stub. Check with the Autonomic service to learn what is the best stub to use for the
+        // service.
     }
 
     private void printToken(TokenSupplier tokenSupplier, String partialMsg) {

--- a/examples/gradle-example/src/test/java/com/autonomic/tmc/example/auth/GradleAuthExampleTest.java
+++ b/examples/gradle-example/src/test/java/com/autonomic/tmc/example/auth/GradleAuthExampleTest.java
@@ -29,9 +29,9 @@ class GradleAuthExampleTest {
     void givenBadCredentials_whenAuthenticating_thenVerifyErrorMessageContainsSdkVersion() {
         GradleAuthExample.LOGGER = loggerStub;
         example.run("hi");
-        Mockito.verify(GradleAuthExample.LOGGER, Mockito.times(2)).log(
+        Mockito.verify(GradleAuthExample.LOGGER, Mockito.times(1)).log(
             eq(Level.SEVERE),
-            eq("Generic message, Something went wrong: "),
+            eq("Example 1: REST Authentication token for Production failed: "),
             errorMessages.capture());
         String actualError = errorMessages.getAllValues().get(0).getMessage();
 

--- a/examples/gradle-example/src/test/java/com/autonomic/tmc/example/auth/GradleAuthExampleTest.java
+++ b/examples/gradle-example/src/test/java/com/autonomic/tmc/example/auth/GradleAuthExampleTest.java
@@ -1,6 +1,6 @@
 package com.autonomic.tmc.example.auth;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.logging.Level;
@@ -29,15 +29,16 @@ class GradleAuthExampleTest {
     void givenBadCredentials_whenAuthenticating_thenVerifyErrorMessageContainsSdkVersion() {
         GradleAuthExample.LOGGER = loggerStub;
         example.run("hi");
-        Mockito.verify(GradleAuthExample.LOGGER).log(
+        Mockito.verify(GradleAuthExample.LOGGER, Mockito.times(2)).log(
             eq(Level.SEVERE),
             eq("Generic message, Something went wrong: "),
             errorMessages.capture());
         String actualError = errorMessages.getAllValues().get(0).getMessage();
 
-        assertTrue(actualError.contains("tmc-auth"));
-        assertTrue(actualError.contains("-SERVICE"));
-        assertTrue(actualError.contains("Authorization failed for user [NOTAREALCLIENTID]"));
+        assertThat(actualError)
+            .contains("tmc-auth")
+            .contains("-SERVICE")
+            .contains("Authorization failed for user [NOTAREALCLIENTID]");
     }
 
     private static class LoggerStub extends Logger {

--- a/examples/maven-example/src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java
+++ b/examples/maven-example/src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java
@@ -23,10 +23,10 @@ public class MavenAuthExample implements CommandLineRunner {
     @VisibleForTesting
     static Logger LOGGER = Logger.getLogger("MavenAuthExample");
 
-    @Value("${tmc.auth.clientId}")
+    @Value("${tmc.auth.clientId: }")
     private String clientId;
 
-    @Value("${tmc.auth.clientSecret}")
+    @Value("${tmc.auth.clientSecret: }")
     private String clientSecret;
 
     @Value("${tmc.auth.tokenUrl:https://accounts.autonomic.ai/v1/auth/oidc/token}")

--- a/examples/maven-example/src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java
+++ b/examples/maven-example/src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java
@@ -51,16 +51,24 @@ public class MavenAuthExample implements CommandLineRunner {
 
     private void run() {
         try {
-            TokenSupplier tokenSupplier;
+            TokenSupplier tokenSupplier = null;
 
             //#Example 1: REST Authentication token for Production
-            tokenSupplier = createTokenSupplier(clientId, clientSecret);
-            printToken(tokenSupplier, "with default URL");
+            try {
+                tokenSupplier = createTokenSupplier(clientId, clientSecret);
+                printToken(tokenSupplier, "with default URL");
+            } catch (RuntimeException e) {
+                e.printStackTrace();
+            }
 
             //Example 2: REST Authentication token when you want to tell the tokenSupplier what
             // environment to connect to
-            tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
-            printToken(tokenSupplier, "with provided URL");
+            try {
+                tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
+                printToken(tokenSupplier, "with provided URL");
+            } catch (RuntimeException e) {
+                e.printStackTrace();
+            }
 
             //Example 3: An authenticated gRPC channel that can be used when creating a client stub
             AuthenticatedChannelBuilder channelBuilder = new AuthenticatedChannelBuilder(

--- a/examples/maven-example/src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java
+++ b/examples/maven-example/src/main/java/com/autonomic/tmc/example/auth/MavenAuthExample.java
@@ -56,7 +56,8 @@ public class MavenAuthExample implements CommandLineRunner {
             tokenSupplier = createTokenSupplier(clientId, clientSecret);
             printToken(tokenSupplier, "with default URL");
         } catch (BaseSdkException e) {
-            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+            LOGGER.log(Level.SEVERE,
+                "Example 1: REST Authentication token for Production failed: ", e);
         }
 
         //Example 2: REST Authentication token when you want to tell the tokenSupplier what
@@ -65,7 +66,8 @@ public class MavenAuthExample implements CommandLineRunner {
             tokenSupplier = createTokenSupplierWithTokenUrl(clientId, clientSecret, tokenUrl);
             printToken(tokenSupplier, "with provided URL");
         } catch (BaseSdkException e) {
-            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+            LOGGER.log(Level.SEVERE,
+                "Example 2: REST Authentication token for your environment failed: ", e);
         }
 
         //Example 3: An authenticated gRPC channel that can be used when creating a client stub
@@ -78,7 +80,8 @@ public class MavenAuthExample implements CommandLineRunner {
             String msg = format("Authenticated Channel: %s", authenticatedGRPCChannel);
             LOGGER.info(msg);
         } catch (BaseSdkException | MalformedURLException e) {
-            LOGGER.log(Level.SEVERE, "Generic message, Something went wrong: ", e);
+            LOGGER.log(Level.SEVERE,
+                "Example 3: A gRPC authenticated token failed: ", e);
         }
 
         // ExampleStub exampleStub = ExampleGrpc.newStub(authenticatedGRPCChannel);

--- a/examples/maven-example/src/test/java/com/autonomic/tmc/example/auth/MavenAuthExampleTest.java
+++ b/examples/maven-example/src/test/java/com/autonomic/tmc/example/auth/MavenAuthExampleTest.java
@@ -1,6 +1,6 @@
 package com.autonomic.tmc.example.auth;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.logging.Level;
@@ -27,17 +27,21 @@ class MavenAuthExampleTest {
 
     @Test
     void givenBadCredentials_whenAuthenticating_thenVerifyErrorMessageContainsSdkVersion() {
+        // Arrange
         MavenAuthExample.LOGGER = loggerStub;
+        // Act
         example.run("hi");
-        Mockito.verify(MavenAuthExample.LOGGER).log(
+        // Assert
+        Mockito.verify(MavenAuthExample.LOGGER, Mockito.times(2)).log(
             eq(Level.SEVERE),
             eq("Generic message, Something went wrong: "),
             errorMessages.capture());
         String actualError = errorMessages.getAllValues().get(0).getMessage();
 
-        assertTrue(actualError.contains("tmc-auth"));
-        assertTrue(actualError.contains("-SERVICE"));
-        assertTrue(actualError.contains("Authorization failed for user [NOTAREALCLIENTID]"));
+        assertThat(actualError)
+            .contains("tmc-auth")
+            .contains("-SERVICE")
+            .contains("Authorization failed for user [NOTAREALCLIENTID]");
     }
 
     private static class LoggerStub extends Logger {

--- a/examples/maven-example/src/test/java/com/autonomic/tmc/example/auth/MavenAuthExampleTest.java
+++ b/examples/maven-example/src/test/java/com/autonomic/tmc/example/auth/MavenAuthExampleTest.java
@@ -32,9 +32,9 @@ class MavenAuthExampleTest {
         // Act
         example.run("hi");
         // Assert
-        Mockito.verify(MavenAuthExample.LOGGER, Mockito.times(2)).log(
+        Mockito.verify(MavenAuthExample.LOGGER, Mockito.times(1)).log(
             eq(Level.SEVERE),
-            eq("Generic message, Something went wrong: "),
+            eq("Example 1: REST Authentication token for Production failed: "),
             errorMessages.capture());
         String actualError = errorMessages.getAllValues().get(0).getMessage();
 

--- a/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
+++ b/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
@@ -38,9 +38,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.codehaus.plexus.util.StringUtils;
+import sun.invoke.empty.Empty;
 
 /**
  * This class provides an OAuth 2.0 - Client Credentials Grant based implementation of {@link
@@ -95,25 +98,26 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
         this.tokenUrl = (tokenUrl != null) ? tokenUrl : DEFAULT_TOKEN_URL;
         try {
             this.tokenEndpoint = new URI(this.tokenUrl);
-        } catch (URISyntaxException e) {
+//            if (this.tokenUrl.trim().isEmpty()) {
+//                throw new RuntimeException("test");
+//            }
+        } catch (RuntimeException | URISyntaxException e) {
             throw new SdkClientException(
                 String.format("tokenUrl [%s] is not a valid URL", tokenUrl), e);
         }
     }
 
     /**
-     * This method responds with a valid String representation of the Bearer token.  If a token
-     * becomes expired, a new valid token will be requested automatically. This method will always
-     * return a valid token.
+     * This method responds with a valid String representation of the Bearer token.  If a token becomes expired, a new valid token will be
+     * requested automatically. This method will always return a valid token.
      *
      * @return String representation of Bearer token.
-     * @throws SdkServiceException Thrown when an unexpected condition is encountered while making
-     * the client credentials grant POST
-     * @throws SdkClientException Thrown when the credentials that were provided are expressly
-     * rejected.
+     * @throws SdkServiceException Thrown when an unexpected condition is encountered while making the client credentials grant POST
+     * @throws SdkClientException Thrown when the credentials that were provided are expressly rejected.
      */
     @Override
     public synchronized String get() {
+        // TODO: Wrap with try catch and trap all exceptions
         if (token != null && !token.isExpired()) {
             log.debug("Cached token found.");
             return token.getValue();
@@ -182,13 +186,13 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
         HTTPResponse response;
         try {
             response = request.toHTTPRequest().send();
-        } catch (IOException e) {
+        } catch (RuntimeException | IOException e) {
             throw new SdkServiceException(String
                 .format("Unexpected issue communicating with tokenUrl [%s]", this.tokenUrl), e);
         }
         try {
             return TokenResponse.parse(response);
-        } catch (ParseException e) {
+        } catch (RuntimeException | ParseException e) {
             throw new SdkClientException(String
                 .format("Unexpected issue parsing token response: [%s]", response.getContent()), e);
         }

--- a/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
+++ b/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
@@ -24,7 +24,6 @@ import com.autonomic.tmc.auth.exception.SdkServiceException;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 import com.nimbusds.oauth2.sdk.ClientCredentialsGrant;
-import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
@@ -33,17 +32,13 @@ import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Objects;
-import java.util.Optional;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.codehaus.plexus.util.StringUtils;
-import sun.invoke.empty.Empty;
 
 /**
  * This class provides an OAuth 2.0 - Client Credentials Grant based implementation of {@link
@@ -98,9 +93,6 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
         this.tokenUrl = (tokenUrl != null) ? tokenUrl : DEFAULT_TOKEN_URL;
         try {
             this.tokenEndpoint = new URI(this.tokenUrl);
-//            if (this.tokenUrl.trim().isEmpty()) {
-//                throw new RuntimeException("test");
-//            }
         } catch (RuntimeException | URISyntaxException e) {
             throw new SdkClientException(
                 String.format("tokenUrl [%s] is not a valid URL", tokenUrl), e);
@@ -117,7 +109,6 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
      */
     @Override
     public synchronized String get() {
-        // TODO: Wrap with try catch and trap all exceptions
         if (token != null && !token.isExpired()) {
             log.debug("Cached token found.");
             return token.getValue();
@@ -186,13 +177,13 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
         HTTPResponse response;
         try {
             response = request.toHTTPRequest().send();
-        } catch (RuntimeException | IOException e) {
+        } catch (Throwable e) {
             throw new SdkServiceException(String
                 .format("Unexpected issue communicating with tokenUrl [%s]", this.tokenUrl), e);
         }
         try {
             return TokenResponse.parse(response);
-        } catch (RuntimeException | ParseException e) {
+        } catch (Throwable e) {
             throw new SdkClientException(String
                 .format("Unexpected issue parsing token response: [%s]", response.getContent()), e);
         }

--- a/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
+++ b/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
@@ -91,6 +91,9 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
         this.clientSecret = clientSecret;
 
         this.tokenUrl = (tokenUrl != null) ? tokenUrl : DEFAULT_TOKEN_URL;
+        if (this.tokenUrl.trim().isEmpty()) {
+            throw new SdkClientException("tokenUrl must not be empty");
+        }
         try {
             this.tokenEndpoint = new URI(this.tokenUrl);
         } catch (RuntimeException | URISyntaxException e) {

--- a/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
+++ b/src/main/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplier.java
@@ -19,6 +19,8 @@
  */
 package com.autonomic.tmc.auth;
 
+import static org.codehaus.plexus.util.StringUtils.isNotBlank;
+
 import com.autonomic.tmc.auth.exception.SdkClientException;
 import com.autonomic.tmc.auth.exception.SdkServiceException;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
@@ -36,7 +38,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -55,6 +59,7 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
     // properties
     private final String clientId;
     private final String clientSecret;
+    @Getter(AccessLevel.PACKAGE) // Visible for testing
     private final String tokenUrl;
     private final URI tokenEndpoint;
 
@@ -80,8 +85,8 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
      * @param clientId     The client_id param of the client credentials request
      * @param clientSecret The client_secret param of the client credentials request
      * @param tokenUrl     The URL against which the client credentials request will POST. A null
-     *                     value will result in the default value being used. Default:
-     *                     https://accounts.autonomic.ai/v1/auth/oidc/token
+     *                      or blank value will result in the default value being used.
+     *                      Default: https://accounts.autonomic.ai/v1/auth/oidc/token
      */
     @Builder
     public ClientCredentialsTokenSupplier(String clientId, String clientSecret, String tokenUrl) {
@@ -90,10 +95,8 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
 
-        this.tokenUrl = (tokenUrl != null) ? tokenUrl : DEFAULT_TOKEN_URL;
-        if (this.tokenUrl.trim().isEmpty()) {
-            throw new SdkClientException("tokenUrl must not be empty");
-        }
+        this.tokenUrl = isNotBlank(tokenUrl) ? tokenUrl : DEFAULT_TOKEN_URL;
+
         try {
             this.tokenEndpoint = new URI(this.tokenUrl);
         } catch (RuntimeException | URISyntaxException e) {

--- a/src/main/java/com/autonomic/tmc/auth/exception/BaseSdkException.java
+++ b/src/main/java/com/autonomic/tmc/auth/exception/BaseSdkException.java
@@ -28,6 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BaseSdkException extends RuntimeException {
 
+    private static final String DEFAULT_NAME = "[ AUTONOMIC ]";
+    private static final String DEFAULT_VERSION = "[ SDK ]";
+
     BaseSdkException(String message) {
         super(message);
         log.warn(message);
@@ -41,11 +44,11 @@ public class BaseSdkException extends RuntimeException {
     static String buildMessage(ErrorSourceType errorSourceType, String clientMessage) {
         try {
             final ProjectProperties properties = ProjectProperties.get();
-            final String name = ofNullable(properties.getName()).orElseGet(() -> "[ AUTONOMIC ]");
-            final String version = ofNullable(properties.getVersion()).orElseGet(() -> "[ SDK ]");
+            final String name = ofNullable(properties.getName()).orElse(DEFAULT_NAME);
+            final String version = ofNullable(properties.getVersion()).orElse(DEFAULT_VERSION);
             return String.format("%s-%s-%s: %s.", name, version, errorSourceType, clientMessage);
         } catch (Throwable e) {
-            return "[ AUTONOMIC! ]-[ SDK! ]-" + errorSourceType.toString() + clientMessage;
+            return DEFAULT_NAME + "~" + DEFAULT_VERSION + "~" + errorSourceType.toString() + clientMessage;
         }
     }
 
@@ -55,7 +58,7 @@ public class BaseSdkException extends RuntimeException {
 
         Manifest manifest;
 
-        ProjectProperties() {
+        private ProjectProperties() {
             setManifest();
         }
 
@@ -93,11 +96,11 @@ public class BaseSdkException extends RuntimeException {
         }
 
         String getName() {
-            return getAttribute("Implementation-Title", "[ AUTONOMIC ]");
+            return getAttribute("Implementation-Title", DEFAULT_NAME);
         }
 
         String getVersion() {
-            return getAttribute("Implementation-Version", "[ SDK ]");
+            return getAttribute("Implementation-Version", DEFAULT_VERSION);
         }
     }
 }

--- a/src/main/java/com/autonomic/tmc/auth/exception/BaseSdkException.java
+++ b/src/main/java/com/autonomic/tmc/auth/exception/BaseSdkException.java
@@ -41,11 +41,11 @@ public class BaseSdkException extends RuntimeException {
     static String buildMessage(ErrorSourceType errorSourceType, String clientMessage) {
         try {
             final ProjectProperties properties = ProjectProperties.get();
-            String name = ofNullable(properties.getName()).orElseGet(() -> "[ AUTONOMIC ]");
-            String version = ofNullable(properties.getVersion()).orElseGet(() -> "[ SDK ]");
+            final String name = ofNullable(properties.getName()).orElseGet(() -> "[ AUTONOMIC ]");
+            final String version = ofNullable(properties.getVersion()).orElseGet(() -> "[ SDK ]");
             return String.format("%s-%s-%s: %s.", name, version, errorSourceType, clientMessage);
         } catch (Throwable e) {
-            return "[ AUTONOMIC! ]-[ SDK ]-" + errorSourceType.toString() + clientMessage;
+            return "[ AUTONOMIC! ]-[ SDK! ]-" + errorSourceType.toString() + clientMessage;
         }
     }
 

--- a/src/main/java/com/autonomic/tmc/auth/exception/SdkClientException.java
+++ b/src/main/java/com/autonomic/tmc/auth/exception/SdkClientException.java
@@ -24,4 +24,8 @@ public class SdkClientException extends BaseSdkException {
     public SdkClientException(String clientMessage, Throwable cause) {
         super(buildMessage(ErrorSourceType.SDK_CLIENT, clientMessage), cause);
     }
+
+    public SdkClientException(String clientMessage) {
+        super(buildMessage(ErrorSourceType.SDK_CLIENT, clientMessage));
+    }
 }

--- a/src/main/java/com/autonomic/tmc/auth/exception/SdkServiceException.java
+++ b/src/main/java/com/autonomic/tmc/auth/exception/SdkServiceException.java
@@ -20,7 +20,9 @@
 package com.autonomic.tmc.auth.exception;
 
 import static com.autonomic.tmc.auth.exception.ErrorSourceType.SERVICE;
+import static java.util.Optional.ofNullable;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import java.util.Objects;
 
@@ -35,7 +37,9 @@ public class SdkServiceException extends BaseSdkException {
     public SdkServiceException(String clientMessage, TokenErrorResponse errorResponse) {
         super(buildMessage(clientMessage, errorResponse));
         if (Objects.nonNull(errorResponse)) {
-            httpStatusCode = errorResponse.getErrorObject().getHTTPStatusCode();
+            final ErrorObject error = ofNullable(errorResponse.getErrorObject())
+                .orElseGet(() -> new ErrorObject("0"));
+            httpStatusCode = error.getHTTPStatusCode();
         }
     }
 
@@ -46,9 +50,11 @@ public class SdkServiceException extends BaseSdkException {
     private static String buildMessage(String clientMessage, TokenErrorResponse errorResponse) {
         StringBuilder sb = new StringBuilder(buildMessage(SERVICE, clientMessage));
         if (Objects.nonNull(errorResponse)) {
+            final ErrorObject error = ofNullable(errorResponse.getErrorObject())
+                .orElseGet(() -> new ErrorObject("0"));
             sb.append(String.format("Error: code=%s and httpStatusCode=%s",
-                    errorResponse.getErrorObject().getCode(),
-                    errorResponse.getErrorObject().getHTTPStatusCode()));
+                ofNullable(error.getCode()).orElseGet(()->"0"),
+                error.getHTTPStatusCode()));
         }
         return sb.toString();
     }

--- a/src/test/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplierTest.java
+++ b/src/test/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplierTest.java
@@ -67,9 +67,6 @@ class ClientCredentialsTokenSupplierTest {
 
         // What happens if tokenUrl is:
         // valid - incorrect url - [done]
-        // malformd - [done]
-        // RFC 2396 - "http:\\google.com -[done]
-        // invalid - correct url
         // not asserting inner-exceptions
 //        assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> {
 //            ClientCredentialsTokenSupplier.builder()
@@ -114,7 +111,7 @@ class ClientCredentialsTokenSupplierTest {
                 .tokenUrl("    ")
                 .build().get();
 
-        });
+        }).withMessageContaining("tokenUrl must not be empty");
     }
 
     @Test

--- a/src/test/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplierTest.java
+++ b/src/test/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplierTest.java
@@ -30,6 +30,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.Mockito.when;
 
 import com.autonomic.tmc.auth.exception.SdkClientException;
 import com.autonomic.tmc.auth.exception.SdkServiceException;
@@ -37,6 +39,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.log4j.BasicConfigurator;
 import org.junit.jupiter.api.AfterEach;
@@ -44,7 +47,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 @Slf4j
 class ClientCredentialsTokenSupplierTest {
@@ -65,6 +71,34 @@ class ClientCredentialsTokenSupplierTest {
         authServer.stop();
     }
 
+    @ParameterizedTest(name = "Given Cause: {1}")
+    @MethodSource("exceptionsToTest")
+    void anyExceptionThrown_alwaysRethrowsAsSdkException(String expectedMessage, Throwable cause,
+        Class expectedExceptionOfType) {
+        startAuthStub();
+
+        assertThatExceptionOfType(expectedExceptionOfType).isThrownBy(() -> {
+            ClientCredentialsTokenSupplier supplier = buildSupplierForStub();
+
+            Token token = Mockito.mock(Token.class);
+            supplier.setToken(token);
+            when(token.getValue()).thenThrow(cause);
+            // Act
+            supplier.get();
+        }).withMessageContaining(expectedMessage)
+            .withCauseInstanceOf(RuntimeException.class);
+    }
+
+    private static Stream<Arguments> exceptionsToTest() {
+        RuntimeException cause = new RuntimeException("Bada!");
+        final String expectedMessage = "Boom!";
+        return Stream.of(
+            of(expectedMessage, new SdkClientException(expectedMessage, cause), SdkClientException.class),
+            of(expectedMessage, new SdkServiceException(expectedMessage, cause), SdkServiceException.class),
+            of("Undocumented exception occurred", new RuntimeException(expectedMessage), SdkClientException.class)
+        );
+    }
+
     @Test
     void actuallyValidUrl_hasInvalidCharacters_wrapsAndPropagatesException() {
         assertThatExceptionOfType(SdkServiceException.class).isThrownBy(() -> {
@@ -79,6 +113,7 @@ class ClientCredentialsTokenSupplierTest {
 
     @Nested
     class ConstructorOnly {
+
         @Test
         void rfc2396_tokenUrlSyntax_throwsSdkClientException() {
             assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> {
@@ -156,12 +191,7 @@ class ClientCredentialsTokenSupplierTest {
         );
 
         // and a token supplier
-        ClientCredentialsTokenSupplier tokenSupplier = ClientCredentialsTokenSupplier
-            .builder()
-            .clientId("a-client-id")
-            .clientSecret("a-client-secret")
-            .tokenUrl("http://localhost:" + authServer.port() + "/relative-token-url")
-            .build();
+        ClientCredentialsTokenSupplier tokenSupplier = buildSupplierForStub();
 
         // an auth failure exception is thrown when token is requested
         assertThatThrownBy(tokenSupplier::get)
@@ -169,7 +199,6 @@ class ClientCredentialsTokenSupplierTest {
             .hasMessageContaining("Authorization failed for user [")
             .hasMessageContaining("at tokenUrl [")
             .hasFieldOrPropertyWithValue("httpStatusCode", responseCode);
-
     }
 
     @ParameterizedTest
@@ -185,12 +214,7 @@ class ClientCredentialsTokenSupplierTest {
         );
 
         // and a token supplier
-        ClientCredentialsTokenSupplier tokenSupplier = ClientCredentialsTokenSupplier
-            .builder()
-            .clientId("a-client-id")
-            .clientSecret("a-client-secret")
-            .tokenUrl("http://localhost:" + authServer.port() + "/relative-token-url")
-            .build();
+        ClientCredentialsTokenSupplier tokenSupplier = buildSupplierForStub();
 
         // a communication exception is thrown when token is requested
         assertThatThrownBy(tokenSupplier::get)
@@ -198,7 +222,6 @@ class ClientCredentialsTokenSupplierTest {
             .hasMessageContaining("Unexpected response [")
             .hasMessageContaining("from tokenUrl [")
             .hasFieldOrPropertyWithValue("httpStatusCode", responseCode);
-
     }
 
     @Test
@@ -214,30 +237,16 @@ class ClientCredentialsTokenSupplierTest {
 
         // an exception is thrown when token is requested
         assertThrows(SdkServiceException.class, tokenSupplier::get);
-
     }
 
     @Test
-    void does_not_request_new_token_until_token_expires() throws Exception {
+    void does_not_request_new_token_until_token_expires() {
 
         // given a valid response with token that expires in 1 second
-        authServer.stubFor(
-            post("/relative-token-url")
-                .willReturn(
-                    aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withStatus(200)
-                        .withBody(sampleOauthResponse())
-                )
-        );
+        startAuthStub();
 
         // and a client
-        ClientCredentialsTokenSupplier tokenSupplier = ClientCredentialsTokenSupplier
-            .builder()
-            .clientId("a-client-id")
-            .clientSecret("a-client-secret")
-            .tokenUrl("http://localhost:" + authServer.port() + "/relative-token-url")
-            .build();
+        ClientCredentialsTokenSupplier tokenSupplier = buildSupplierForStub();
 
         //when an auth token is retrieved 3 times
         tokenSupplier.get();
@@ -256,11 +265,10 @@ class ClientCredentialsTokenSupplierTest {
 
         //then a second call was made
         authServer.verify(2, postRequestedFor(urlEqualTo("/relative-token-url")));
-
     }
 
     @Test
-    void sends_the_correct_request_and_maps_response() throws Exception {
+    void sends_the_correct_request_and_maps_response() {
 
         //given a 200 response when params match
         authServer.stubFor(
@@ -276,12 +284,7 @@ class ClientCredentialsTokenSupplierTest {
         );
 
         //and a client
-        ClientCredentialsTokenSupplier tokenSupplier = ClientCredentialsTokenSupplier
-            .builder()
-            .clientId("a-client-id")
-            .clientSecret("a-client-secret")
-            .tokenUrl("http://localhost:" + authServer.port() + "/relative-token-url")
-            .build();
+        ClientCredentialsTokenSupplier tokenSupplier = buildSupplierForStub();
 
         //when an auth token is retrieved
         String token = tokenSupplier.get();
@@ -295,4 +298,23 @@ class ClientCredentialsTokenSupplierTest {
         return "{\"access_token\":\"mock-auth-token\",\"expires_in\":\"11\",\"token_type\":\"bearer\"}";
     }
 
+    private void startAuthStub() {
+        authServer.stubFor(
+            post("/relative-token-url")
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)
+                        .withBody(sampleOauthResponse())
+                )
+        );
+    }
+
+    private ClientCredentialsTokenSupplier buildSupplierForStub() {
+        return ClientCredentialsTokenSupplier.builder()
+            .clientId("a-client-id")
+            .clientSecret("a-client-secret")
+            .tokenUrl("http://localhost:" + authServer.port() + "/relative-token-url")
+            .build();
+    }
 }

--- a/src/test/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplierTest.java
+++ b/src/test/java/com/autonomic/tmc/auth/ClientCredentialsTokenSupplierTest.java
@@ -66,8 +66,6 @@ class ClientCredentialsTokenSupplierTest {
         // TODO: Ensure that no Exceptions can escape
 
         // What happens if tokenUrl is:
-        // null
-        // empty string [commented logic]
         // valid - incorrect url - [done]
         // malformd - [done]
         // RFC 2396 - "http:\\google.com -[done]
@@ -81,6 +79,10 @@ class ClientCredentialsTokenSupplierTest {
 //                .build();
 //
 //        }).withCause(new RuntimeException("test"));
+        }
+
+    @Test
+    void seeminglyValidUrl_hasInvalidCharacters_wrapsAndPropogatesException() {
         assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> {
             ClientCredentialsTokenSupplier.builder()
                 .clientSecret("a-secret")
@@ -89,7 +91,10 @@ class ClientCredentialsTokenSupplierTest {
                 .build();
 
         }).withCauseInstanceOf(URISyntaxException.class);
+    }
 
+    @Test
+    void actuallyValidUrl_hasInvalidCharacters_wrapsAndPropogatesException() {
         assertThatExceptionOfType(SdkServiceException.class).isThrownBy(() -> {
             ClientCredentialsTokenSupplier.builder()
                 .clientSecret("a-secret")
@@ -98,23 +103,30 @@ class ClientCredentialsTokenSupplierTest {
                 .build().get();
 
         }).withMessageContaining("405");
-        assertThatExceptionOfType(SdkServiceException.class).isThrownBy(() -> {
+    }
+
+    @Test
+    void emptyUrl_hasInvalidCharacters_wrapsAndPropogatesException() {
+        assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> {
             ClientCredentialsTokenSupplier.builder()
                 .clientSecret("a-secret")
                 .clientId("a-client-id")
-                .tokenUrl("")
+                .tokenUrl("    ")
                 .build().get();
 
         });
     }
 
     @Test
-    void test21() {
-        ClientCredentialsTokenSupplier.builder()
-            .clientSecret("a-secret")
-            .clientId("a-client-id")
-            .tokenUrl("")
-            .build().get();
+    void nullUrl_hasInvalidCharacters_wrapsAndPropogatesServiceException() {
+        assertThatExceptionOfType(SdkServiceException.class).isThrownBy(() -> {
+            ClientCredentialsTokenSupplier.builder()
+                .clientSecret("a-secret")
+                .clientId("a-client-id")
+                .tokenUrl(null)
+                .build().get();
+
+        });
     }
 
     @Test

--- a/src/test/java/com/autonomic/tmc/auth/exception/BaseSdkExceptionTest.java
+++ b/src/test/java/com/autonomic/tmc/auth/exception/BaseSdkExceptionTest.java
@@ -20,11 +20,22 @@
 package com.autonomic.tmc.auth.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.when;
 
 import com.autonomic.tmc.auth.exception.BaseSdkException.ProjectProperties;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class BaseSdkExceptionTest {
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+class BaseSdkExceptionTest {
+
+    @Mock
+    private ProjectProperties mockProperties;
 
     @Test
     void projectProperties_returnsUnknown_when_POMFileNotFound() {
@@ -33,4 +44,33 @@ public class BaseSdkExceptionTest {
         assertThat(projectProperties.getName()).isEqualTo("[ UNKNOWN ]");
         assertThat(projectProperties.getVersion()).isEqualTo("[ UNKNOWN ]");
     }
+
+    @Test
+    void initializeProjectProperties_throwsRuntimeException_doesNotCauseExceptionInitializer() {
+        when(mockProperties.getName()).thenThrow(new RuntimeException("End of the world"));
+
+//        final String actualMessage = BaseSdkException.buildMessage(ErrorSourceType.SERVICE, "unit test");
+//        assertThat(actualMessage).contains("AUTONOMIC");
+//        assertThat(actualMessage).contains("SDK");
+
+        try {
+            BaseSdkException.initializeProjectProperties(mockProperties);
+        } catch (Throwable e) {
+            fail("exceptions must not be thrown");
+        }
+        final String actualMessage2 = BaseSdkException.buildMessage(ErrorSourceType.SERVICE, "unit test");
+        assertThat(actualMessage2).contains("AUTONOMIC");
+        assertThat(actualMessage2).contains("SDK");
+    }
+
+    @Test
+    void initializeProjectProperties_withNull_thenNoExceptionThrown() {
+        try {
+            new BaseSdkException("something");
+        } catch (Throwable e) {
+            fail("exceptions must not be thrown");
+        }
+    }
+
+
 }

--- a/src/test/java/com/autonomic/tmc/auth/exception/BaseSdkExceptionTest.java
+++ b/src/test/java/com/autonomic/tmc/auth/exception/BaseSdkExceptionTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.autonomic.tmc.auth.exception.BaseSdkException.ProjectProperties;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import java.util.jar.Manifest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +42,10 @@ class BaseSdkExceptionTest {
     void setup() {
         mockManifest = mock(Manifest.class);
         mockProperties = mock(ProjectProperties.class);
+    }
+
+    @AfterEach
+    void tearDown() {
         ProjectProperties.singletonInstance=null;
     }
 

--- a/src/test/java/com/autonomic/tmc/auth/exception/BaseSdkExceptionTest.java
+++ b/src/test/java/com/autonomic/tmc/auth/exception/BaseSdkExceptionTest.java
@@ -150,7 +150,7 @@ class BaseSdkExceptionTest {
         when(mockProperties.getName()).thenThrow(new RuntimeException("Bada"));
 
         BaseSdkException actual = new SdkClientException("test", new RuntimeException("Boom!"));
-        assertThat(actual.getMessage()).contains("[ AUTONOMIC! ]");
+        assertThat(actual.getMessage()).contains("[ AUTONOMIC ]~");
     }
 
     @Test
@@ -160,7 +160,7 @@ class BaseSdkExceptionTest {
         when(mockProperties.getVersion()).thenThrow(new RuntimeException("Bada"));
 
         BaseSdkException actual = new SdkClientException("test", new RuntimeException("Boom!"));
-        assertThat(actual.getMessage()).contains("[ SDK! ]");
+        assertThat(actual.getMessage()).contains("[ SDK ]~");
     }
 
     @Test


### PR DESCRIPTION
- No matter what, do not throw exceptions during Exception Creation
- Ensure all exceptions are wrapped with SdkException
- Update mvn example to show try catch of all exceptions
- Update gradle example to show try catch of all exceptions
